### PR TITLE
Fix(app): Correct Abstraxion RPC URL and configure EAS build

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -6,7 +6,7 @@ import MainApp from './MainApp';
 
 const App = () => {
   const config = {
-    rpcUrl: 'https://accounts.spotify.com/authorize',
+    rpcUrl: 'https://rpc.xion-testnet-2.burnt.com:443',
     chainId: 'xion-testnet-2'
   };
 

--- a/eas.json
+++ b/eas.json
@@ -1,0 +1,14 @@
+{
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal"
+    },
+    "preview": {
+      "distribution": "internal"
+    },
+    "production": {
+      "concurrency": 1
+    }
+  }
+}


### PR DESCRIPTION
- Updated the `rpcUrl` in `App.tsx` to the correct endpoint for the XION testnet. This resolves the issue where the 'Login with Abrastraxion' flow would not open.
- Added an `eas.json` file with standard `development`, `preview`, and `production` build profiles to facilitate building the application with Expo Application Services.